### PR TITLE
Adds integers to the opam file.

### DIFF
--- a/integers_stubs_js.opam
+++ b/integers_stubs_js.opam
@@ -14,6 +14,7 @@ depends: [
   "js_of_ocaml" {>= "3.6.0"}
   "zarith_stubs_js"
   "dune"                {build & >= "1.6"}
+  "integers"            {with-test & >= "0.6.0"}
 ]
 synopsis: "Javascript stubs for the integers library in js_of_ocaml"
 description: "


### PR DESCRIPTION
Hi - this project was failing `dune build @runtest` with

```
File "test/dune", line 5, characters 12-20:
5 |  (libraries integers integers_stubs_js))
                ^^^^^^^^
Error: Library "integers" not found.
```

Here is the project building on ocaml-ci -- 

Prior to the fix: build [3c7d33](https://ci.ocamllabs.io/github/novemberkilo/integers_stubs_js/commit/3c7d33c7e86cbf65fef4603e78fee2941c1e28c9)
With this fix: build [db4a1be](https://ci.ocamllabs.io/github/novemberkilo/integers_stubs_js/commit/db4a1bee0e2a8a2713a3afc8e0ebc8c7a2b69632)