### PR TITLE
Fix: converting large uint32 to int64

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -141,7 +141,7 @@ function integers_uint32_to_int(i) {
 //Provides: integers_uint32_to_int64
 //Requires: caml_int64_create_lo_mi_hi
 function integers_uint32_to_int64(i) {
-    return caml_int64_create_lo_mi_hi(i.value & 0xffffff, (i.value >>> 24) & 0xffffff, (i.value >>> 31) & 0xffff);
+    return caml_int64_create_lo_mi_hi(i.value & 0xffffff, (i.value >>> 24) & 0xffffff, 0);
 }
 
 //Provides: integers_uint32_to_string


### PR DESCRIPTION
This fixes a bug when converting `uint32`, which have their most significant bit set, to `int64`. The previous version erroneously used a right-shift by 31 bits to set the highest int64 limb. This should have been a shift by 48. Equivalently, we can just set the highest limb to 0 because a uint32 is not supposed to have any of those bits set.